### PR TITLE
Register a tax applicator in the compiler pass

### DIFF
--- a/src/DependencyInjection/Compiler/TaxApplicatorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TaxApplicatorCompilerPass.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace MangoSylius\PaymentFeePlugin\DependencyInjection\Compiler;
+
+use MangoSylius\PaymentFeePlugin\Model\Taxation\Applicator\OrderPaymentTaxesApplicator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class TaxApplicatorCompilerPass implements CompilerPassInterface
+{
+	/**
+	 * @inheritDoc
+	 */
+	public function process(ContainerBuilder $container)
+	{
+		$this->registerToOrderItemsBasedStrategy($container);
+		$this->registerToOrderItemUnitsBasedStrategy($container);
+	}
+
+	private function registerToOrderItemsBasedStrategy(
+		ContainerBuilder $container
+	): void {
+		$definition = $container->getDefinition(
+			'sylius.taxation.order_items_based_strategy'
+		);
+		$arg = $definition->getArgument(1);
+		$arg[] = new Reference(OrderPaymentTaxesApplicator::class);
+		$definition->setArgument(1, $arg);
+	}
+
+	private function registerToOrderItemUnitsBasedStrategy(
+		ContainerBuilder $container
+	): void {
+		$definition = $container->getDefinition(
+			'sylius.taxation.order_item_units_based_strategy'
+		);
+		$arg = $definition->getArgument(1);
+		$arg[] = new Reference(OrderPaymentTaxesApplicator::class);
+		$definition->setArgument(1, $arg);
+	}
+}

--- a/src/MangoSyliusPaymentFeePlugin.php
+++ b/src/MangoSyliusPaymentFeePlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MangoSylius\PaymentFeePlugin;
 
+use MangoSylius\PaymentFeePlugin\DependencyInjection\Compiler\TaxApplicatorCompilerPass;
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -15,5 +16,6 @@ class MangoSyliusPaymentFeePlugin extends Bundle
 	public function build(ContainerBuilder $container)
 	{
 		$container->addCompilerPass(new DependencyInjection\Compiler\RegisterFeeCalculatorsPass());
+		$container->addCompilerPass(new TaxApplicatorCompilerPass());
 	}
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -79,25 +79,3 @@ services:
             $calculator: '@sylius.tax_calculator'
             $adjustmentFactory: '@sylius.factory.adjustment'
             $taxRateResolver: '@sylius.tax_rate_resolver'
-
-    mango_sylius.taxation.order_items_based_strategy:
-        class: Sylius\Bundle\CoreBundle\Taxation\Strategy\TaxCalculationStrategy
-        decorates: sylius.taxation.order_items_based_strategy
-        tags:
-            - name: sylius.taxation.calculation_strategy
-              type: order_items_based
-              label: 'Order items based'
-        arguments:
-            $type: 'order_items_based'
-            $applicators: ['@sylius.taxation.order_items_taxes_applicator', '@sylius.taxation.order_shipment_taxes_applicator', '@MangoSylius\PaymentFeePlugin\Model\Taxation\Applicator\OrderPaymentTaxesApplicator']
-
-    mango_sylius.taxation.order_item_units_based_strategy:
-        class: Sylius\Bundle\CoreBundle\Taxation\Strategy\TaxCalculationStrategy
-        decorates: sylius.taxation.order_item_units_based_strategy
-        tags:
-            - name: sylius.taxation.calculation_strategy
-              type: order_item_units_based
-              label: 'Order item units based'
-        arguments:
-            $type: order_item_units_based
-            $applicators: ['@sylius.taxation.order_item_units_taxes_applicator', '@sylius.taxation.order_shipment_taxes_applicator', '@MangoSylius\PaymentFeePlugin\Model\Taxation\Applicator\OrderPaymentTaxesApplicator']


### PR DESCRIPTION
The decoration of the OrderTaxesApplicatorInterface in the services.yaml prevents the registration of the other plugins applicators